### PR TITLE
Fix QStyle error in QvkPlayer

### DIFF
--- a/src/player/QvkPlayer.cpp
+++ b/src/player/QvkPlayer.cpp
@@ -3,6 +3,7 @@
 #include "QvkPlayerVideoSurface.h"
 
 #include <QTime>
+#include <QStyle>
 
 QvkPlayer::QvkPlayer(QWidget *parent) : QWidget(parent),
                                         ui(new Ui::QvkPlayer)


### PR DESCRIPTION
`QStyle` is used in QvkPlayer but not included, so it throws:

```
error: incomplete type ‘QStyle’
```