### PR TITLE
Enable "over fullscreen" on Linux.

### DIFF
--- a/src/camera/QvkCameraController.cpp
+++ b/src/camera/QvkCameraController.cpp
@@ -91,16 +91,8 @@ void QvkCameraController::slot_frameOnOff( bool value )
 {
     if ( cameraWindow->isVisible() == true )
     {
-        if ( value == true )
-        {
-            cameraWindow->setWindowFlags( Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint );
-        }
-
-        if ( value == false )
-        {
-            cameraWindow->setWindowFlags( Qt::Window | Qt::WindowStaysOnTopHint );
-        }
-
+//        cameraWindow->hide();
+        cameraWindow->setNoframe( value );
         cameraWindow->show();
     }
 }
@@ -108,20 +100,7 @@ void QvkCameraController::slot_frameOnOff( bool value )
 
 void QvkCameraController::slot_sliderMoved( int value )
 {
-    if ( value == 1 )
-    {
-        cameraWindow->resize( 160, 120 );
-    }
-
-    if ( value == 2 )
-    {
-        cameraWindow->resize( 320, 240 );
-    }
-
-    if ( value == 3 )
-    {
-        cameraWindow->resize( 639, 479 );
-    }
+    cameraWindow->setCameraWindowSize(value);
 }
 
 

--- a/src/camera/QvkCameraWindow.h
+++ b/src/camera/QvkCameraWindow.h
@@ -45,6 +45,8 @@ public:
 
 private:
    Ui_formMainWindow *ui_formMainWindow;
+   bool hasNoFrame;
+   QByteArray position;
 
 
 public slots:
@@ -65,6 +67,11 @@ protected:
 signals:
     void signal_cameraWindow_close( bool );
 
+private:
+    void toggleFullScreen();
+public:
+    void setCameraWindowSize(int value);
+    void setNoframe(bool);
 };
 
 #endif // QVKWEBCAMWINDOW_H

--- a/src/camera/camerasettingsdialog.cpp
+++ b/src/camera/camerasettingsdialog.cpp
@@ -29,7 +29,7 @@ cameraSettingsDialog::cameraSettingsDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::cameraSettingsDialog)
 {
-    setWindowFlags( Qt::Window | Qt::WindowStaysOnTopHint | Qt::Tool );
+    setWindowFlags( Qt::Window | Qt::WindowStaysOnTopHint);
     ui->setupUi(this);
 
     dialog_sliderCameraWindowSize = new QvkSpezialSlider( Qt::Horizontal );

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -523,7 +523,7 @@ void QvkMainWindow::closeEvent( QCloseEvent *event )
                                    vkRegionChoise->getYRecordArea() / vkRegionChoise->screen->devicePixelRatio(),
                                    vkRegionChoise->getWidth() / vkRegionChoise->screen->devicePixelRatio(),
                                    vkRegionChoise->getHeight() / vkRegionChoise->screen->devicePixelRatio() );
-    vkSettings.saveCamera( vkCameraController->cameraWindow->geometry().x(), vkCameraController->cameraWindow->geometry().y() );
+    vkSettings.saveCamera( vkCameraController->cameraWindow->saveGeometry() );
     vkSettings.saveSystrayAlternative( vkSystrayAlternative->x(), vkSystrayAlternative->y() );
     vkSettings.savePlayerPathOpenFile( vkPlayer->pathOpenFile );
     emit signal_close();

--- a/src/settings/QvkSettings.cpp
+++ b/src/settings/QvkSettings.cpp
@@ -323,12 +323,11 @@ void QvkSettings::readAreaScreencast( QvkRegionChoise *vkRegionChoise )
     settings.endGroup();
 }
 
-void QvkSettings::saveCamera( int x, int y )
+void QvkSettings::saveCamera(QByteArray geometry)
 {
     QSettings settings( QSettings::IniFormat, QSettings::UserScope, global::name, global::name, Q_NULLPTR );
     settings.beginGroup( "Camera" );
-    settings.setValue( "X", x );
-    settings.setValue( "Y", y );
+    settings.setValue("geometry", geometry);
     settings.endGroup();
 }
 
@@ -336,7 +335,7 @@ void QvkSettings::readCamera( QvkCameraController *vkCameraController )
 {
     QSettings settings( QSettings::IniFormat, QSettings::UserScope, global::name, global::name, Q_NULLPTR );
     settings.beginGroup( "Camera" );
-    vkCameraController->cameraWindow->move( settings.value( "X", 0 ).toInt(), settings.value( "Y", 0 ).toInt() );
+    vkCameraController->cameraWindow->restoreGeometry(settings.value("geometry").toByteArray());
     settings.endGroup();
 }
 

--- a/src/settings/QvkSettings.h
+++ b/src/settings/QvkSettings.h
@@ -44,7 +44,7 @@ public:
     void readAll(Ui_formMainWindow *ui_mainwindow, QMainWindow *parent);
     void saveAreaScreencast(qreal x, qreal y, qreal width, qreal height);
     void readAreaScreencast(QvkRegionChoise *vkRegionChoise);
-    void saveCamera( int x, int y );
+    void saveCamera( QByteArray geometry );
     void readCamera( QvkCameraController *vkCameraController );
     void saveSystrayAlternative( int x, int y );
     void readSystrayAlternative( QvkSystrayAlternative *vkSystrayAlternative );


### PR DESCRIPTION
vokoscreenNG can display camera window over fullscreen on Windows 10, but cannot on Linux. It worked on vokoscreen (not NG). This patch enable to display camera window over fullscreen on Linux.
But I don't know how to avoid using "sleep" ...