### PR TITLE
Create issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Bug report checklist**
+* [ ] Have you searched the existing issues to see if this report is a duplicate?
+* [ ] Are you using the latest version of vokoscreenNG?
+* [ ] Are you familiar with https://www.mediawiki.org/wiki/How_to_report_a_bug ?
+* [ ] For recording issues, have you included logs from vokoscreenNG after "Start" and "Stop"?
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Log messages**
+If applicable, paste or attach log messages from the vokoscreenNG log tab.
+(Text files saved as `.txt` or `.log` are accepted by GitHub as attachment uploads. `.zip` archives are also permitted.)
+
+<!-- If you copy-paste logs, place the text between the fence markers below to format them properly. -->
+```text
+
+
+
+```

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ ui_*.h
 .*
 !.tx
 !.gitignore
+!.github
 *~


### PR DESCRIPTION
Convert #19 into an Issue Template (with additional structure/content). GitHub will use the template to pre-populate the New Issue textarea, so the user will always see it.

(Also, add an exception to the `.gitignore` file for the `.github/` directory.)

Closes #19 
