### PR TITLE
Fix stuttering/freezing video when webcam is active (fix issue #366)

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1817,9 +1817,9 @@ QString QvkMainWindow::Vk_get_Videocodec_Encoder()
         list << "vp8enc";
         list << "min_quantizer=" + QString::number( sliderVp8->value() );
         list << "max_quantizer=" + QString::number( sliderVp8->value() );
-        list << "cpu-used=" + QString::number( 0 );
+        list << "cpu-used=" + QString::number( QThread::idealThreadCount() );
         list << "deadline=1000000";
-        list << "threads=" + QString::number( 0 );
+        list << "threads=" + QString::number( QThread::idealThreadCount() );
         value = list.join( " " );
     }
 


### PR DESCRIPTION
This patch partially reverts commit 46e9a41b, which was found with git bisect.  One of the changes in that commit didn't seem to fit with the others, and reverting it restored the proper behavior.

In my testing this patch resolves issue #366.