### PR TITLE
Wayland: list PipeWire virtual audio sources (fixes #422 regression)

### DIFF
--- a/src/wayland/audio/QvkAudioPipewireWatcher_wl.cpp
+++ b/src/wayland/audio/QvkAudioPipewireWatcher_wl.cpp
@@ -47,17 +47,25 @@ GstBusSyncReply QvkAudioPipewireWatcher_wl::my_AudioPipewire_func(GstBus *bus, G
         GstDevice *gstDevice;
         gst_message_parse_device_added( message, &gstDevice );
         GstStructure *structure = gst_device_get_properties( gstDevice );
-        QString api = QString( gst_structure_get_string( structure, "device.api" ) );
-        if ( api == "alsa" ) {
+        QString mediaClass = QString( gst_structure_get_string( structure, "media.class" ) );
+        // Accept real hardware nodes (Audio/Source, Audio/Sink) and PipeWire virtual
+        // nodes, but skip internal Stream/* followers (e.g. capture.* filter-chain
+        // nodes) that would otherwise duplicate their parent source. Before 4.10.0
+        // the PulseAudio path listed every source; the GstDeviceMonitor migration
+        // narrowed this to device.api == "alsa" and dropped virtual microphones.
+        if ( mediaClass == "Audio/Source" or mediaClass == "Audio/Sink" ) {
             QString deviceID = QString( gst_structure_get_string( structure, "object.serial" ) );
             QString description = QString( gst_structure_get_string( structure, "node.description" ) );
             QString capture = QString( gst_structure_get_string( structure, "api.alsa.pcm.stream" ) );
             QString type;
             if( capture == "capture" ) {
                 type = "Source";
+            } else if ( mediaClass == "Audio/Source" ) {
+                type = "Source";
             } else {
                 type = "Playback";
             }
+            QString api = QString( gst_structure_get_string( structure, "device.api" ) );
             QString action = "[Audio-device-added]";
             QString device = QString( gst_structure_get_string( structure, "node.name" ) );
             global::lineEditAudioPipewireWatcher_wl->setText( deviceID + ":::" +
@@ -79,8 +87,11 @@ GstBusSyncReply QvkAudioPipewireWatcher_wl::my_AudioPipewire_func(GstBus *bus, G
         QString deviceID = QString( gst_structure_get_string( structure, "object.serial" ) );
         QString description = QString( gst_structure_get_string( structure, "node.description" ) );
         QString capture = QString( gst_structure_get_string( structure, "api.alsa.pcm.stream" ) );
+        QString mediaClass = QString( gst_structure_get_string( structure, "media.class" ) );
         QString type;
         if( capture == "capture" ) {
+            type = "Source";
+        } else if ( mediaClass == "Audio/Source" ) {
             type = "Source";
         } else {
             type = "Playback";


### PR DESCRIPTION
## Problem

On Wayland, vokoscreenNG 4.10.0 does not list PipeWire virtual audio sources (e.g. an `rnnoise` noise-cancelling virtual microphone created via `filter-chain`) in the audio device list. Only physical ALSA-backed devices are shown. This is a regression from 4.9.0, introduced by the 4.10.0 audio backend rewrite (PulseAudio API → GStreamer `GstDeviceMonitor`).

Closes #422

## Root cause

`QvkAudioPipewireWatcher_wl::my_AudioPipewire_func` filters every device reported by `GstDeviceMonitor` with:

```cpp
QString api = QString( gst_structure_get_string( structure, "device.api" ) );
if ( api == "alsa" ) {
```

PipeWire virtual nodes (e.g. `rnnoise_source`) have `node.virtual = true`, `media.class = Audio/Source`, but **no `device.api` property**, so they are silently dropped. `gst-device-monitor-1.0 Audio` does report them (`gst-launch-1.0 pipewiresrc target-object=38 ! ...`), so the data is available — only the filter discards it. This also affects other non-ALSA backends (e.g. Bluetooth `device.api = bluez5`).

## Fix

Filter by `media.class` instead of `device.api`:

- Accept `Audio/Source` and `Audio/Sink` (real hardware + PipeWire virtual nodes)
- Skip `Stream/*` internal followers (e.g. `capture.rnnoise_source` filter-chain follower nodes) that would otherwise duplicate their parent source
- Fall back to `media.class` for `type` detection when `api.alsa.pcm.stream` is absent on virtual nodes (applied symmetrically to both `DEVICE_ADDED` and `DEVICE_REMOVED`)

The downstream recording pipeline uses `pipewiresrc target-object=<object.serial>`, which works for virtual nodes, so no further changes are needed.

## Verification

Before (4.10.0, log from #422) — only the three `alsa_*` devices are listed:
```
[Audio][Controller] 63 Added: ... alsa_input.pci-0000_0a_00.4.analog-stereo
[Audio][Controller] 62 Added: ... alsa_output.pci-0000_0a_00.4.analog-stereo
[Audio][Controller] 58 Added: ... alsa_output.pci-0000_08_00.1.hdmi-stereo-extra5
```

After this patch — the virtual source appears, without the duplicate `capture.rnnoise_source` follower:
```
[Audio][Controller] 63 Added: ... alsa_input.pci-0000_0a_00.4.analog-stereo
[Audio][Controller] 62 Added: ... alsa_output.pci-0000_0a_00.4.analog-stereo
[Audio][Controller] 58 Added: ... alsa_output.pci-0000_08_00.1.hdmi-stereo-extra5
[Audio][Controller] 38 Added: Noise Canceling source rnnoise_source
```

Tested on: Wayland (niri), PipeWire 1.6.7, Qt 6.11.1, GStreamer 1.28.4.
